### PR TITLE
fix bugs on capsule card

### DIFF
--- a/app/views/capsules/_info_capsule.html.erb
+++ b/app/views/capsules/_info_capsule.html.erb
@@ -9,8 +9,8 @@
 
 <div class="content">
   <div>
-    <%= cl_image_tag(current_user.avatar.key.presence || 'icons/Photo/logo-capsule.png', class: "capsule-avatar mb-2", alt: "User Avatar") %>
-    <span class="name"><%= current_user.name %></span>
+    <%= cl_image_tag(capsule.user.avatar.key.presence || 'logo-capsule.png', class: "capsule-avatar mb-2", alt: "User Avatar") %>
+    <span class="name"><%= capsule.user.name %></span>
   </div>
   <div class="button-right">
     <% like = capsule.likes.find_by(user: current_user)  %>
@@ -39,5 +39,4 @@
 
 <div>
   <% like = capsule.likes.find_by(user: current_user) %>
-  <%= render "button_like", capsule: capsule, like: like %>
 </div>


### PR DESCRIPTION
[capsule_card] remettre le nom du user qui a posté la capsule, au lieu du current_user. On avait fait la modif il y a qq jours mais le push a du sauter
[capsule_card] le nb de likes s'affiche deux fois, retirer celui en bas à gauche