### PR TITLE
Remove turbo

### DIFF
--- a/app/controllers/capsules_controller.rb
+++ b/app/controllers/capsules_controller.rb
@@ -13,18 +13,8 @@ class CapsulesController < ApplicationController
       {
         lat: capsule.latitude,
         lng: capsule.longitude,
-        infoWindow: render_to_string(partial: "info_capsule", formats: [:html], locals: { capsule: capsule }),
-        marker_html: render_to_string(partial: "marker", formats: [:html], locals: { capsule: capsule})
-      }
-    end
-
-    respond_to do |format|
-      format.html
-      format.turbo_stream {
-        render turbo_stream: [
-          turbo_stream.replace("map", partial: "map", locals: { markers: @markers }),
-          turbo_stream.replace("capsules_list", partial: "capsules_list", locals: { capsules: @capsules })
-        ]
+        infoWindow: render_to_string(partial: "info_capsule", locals: { capsule: capsule }),
+        marker_html: render_to_string(partial: "marker", locals: { capsule: capsule})
       }
     end
 
@@ -38,8 +28,8 @@ class CapsulesController < ApplicationController
     @capsule = Capsule.new(capsule_params)
     @capsule.user = current_user
     if @capsule.save
-      redirect_to root_path(format: :html, lat: @capsule.latitude, lng: @capsule.longitude, zoom: 12, openPopup: true), status: :see_other
-      # redirect_to root_path(lat: @capsule.latitude, lng: @capsule.longitude, zoom: 12, openPopup: true), status: :see_other
+      redirect_to root_path(lat: @capsule.latitude, lng: @capsule.longitude, zoom: 12, openPopup: true)
+      # maybe add the status: :see_other in case of issue after capsule save
     else
       render turbo_stream: turbo_stream.replace("capsule-form", partial: "capsules/form", locals: { capsule: @capsule })
     end

--- a/app/views/capsules/_capsules_list.html.erb
+++ b/app/views/capsules/_capsules_list.html.erb
@@ -1,9 +1,0 @@
-<%= turbo_frame_tag "capsules_list" do %>
-    <ul class="list-unstyled">
-      <% capsules.each do |capsule| %>
-        <li class="mt-2">
-          <%= render "shared/capsule_design", capsule: capsule %>
-      </li>
-        <% end %>
-    </ul>
-<% end %>

--- a/app/views/capsules/_info_capsule.html.erb
+++ b/app/views/capsules/_info_capsule.html.erb
@@ -17,7 +17,7 @@
     <%= render "button_like", capsule: capsule, like: like%>
   </div>
 </div>
-
+ 
 <div>
   <p class="card-description"><%= capsule.teasing %></p>
 </div>

--- a/app/views/capsules/_map.html.erb
+++ b/app/views/capsules/_map.html.erb
@@ -1,7 +1,0 @@
-<%= turbo_frame_tag "map", style:"width: 100vw;" do %>
-  <div style='width: 100%; height: 100vh;'
-      data-controller="map"
-      data-map-api-key-value="<%= ENV['MAPBOX_API_KEY'] %>"
-      data-map-markers-value="<%= markers.to_json %>">
-  </div>
-<% end %>

--- a/app/views/capsules/index.html.erb
+++ b/app/views/capsules/index.html.erb
@@ -1,2 +1,6 @@
-<%= render "map", markers: @markers %>
+<div style='width: 100%; height: 100vh;'
+    data-controller="map"
+    data-map-api-key-value="<%= ENV['MAPBOX_API_KEY'] %>"
+    data-map-markers-value="<%= @markers.to_json %>">
+</div>
 

--- a/app/views/shared/_menu_right.html.erb
+++ b/app/views/shared/_menu_right.html.erb
@@ -1,17 +1,23 @@
-  <div id="right-menu" class="side-menu">
-    <button class="btn close-btn text-muted" data-action="click->menu#closeRightMenu"><i class="bi bi-x-circle"></i></button>
-    <h2 class="text-center p-2 mt-3">Exploration</h2>
+<div id="right-menu" class="side-menu">
+  <button class="btn close-btn text-muted" data-action="click->menu#closeRightMenu"><i class="bi bi-x-circle"></i></button>
+  <h2 class="text-center p-2 mt-3">Exploration</h2>
 
 <div class="d-flex flex-wrap gap-2 p-3 custom-container">
-  <%= link_to "All", root_path(category: "all"), data: {turbo_frame: "under_top"}, class: "btn-category" %>
-  <%= link_to "Histoire", root_path(category: "histoire", format: :turbo_stream), data:{turbo_prefetch: false}, class: "btn-category marker-style-histoire" %>
-  <%= link_to "Art", root_path(category: "art", format: :turbo_stream), data:{turbo_prefetch: false}, class: "btn-category marker-style-art" %>
-  <%= link_to "Love", root_path(category: "love", format: :turbo_stream), data:{turbo_prefetch: false}, class: "btn-category marker-style-love" %>
-  <%= link_to "Architecture", root_path(category: "architecture", format: :turbo_stream), data:{turbo_prefetch: false}, class: "btn-category marker-style-architecture" %>
-  <%= link_to "Horreur", root_path(category: "horreur", format: :turbo_stream), data:{turbo_prefetch: false}, class: "btn-category marker-style-horreur" %>
-  <%= link_to "Nature", root_path(category: "nature", format: :turbo_stream), data:{turbo_prefetch: false}, class: "btn-category marker-style-nature" %>
-  <%= link_to "Fantasy", root_path(category: "fantasy", format: :turbo_stream), data:{turbo_prefetch: false}, class: "btn-category marker-style-fantasy" %>
+  <%= link_to "All", root_path(category: "all"), class: "btn-category" %>
+  <%= link_to "Histoire", root_path(category: "histoire"), class: "btn-category marker-style-histoire" %>
+  <%= link_to "Art", root_path(category: "art"), class: "btn-category marker-style-art" %>
+  <%= link_to "Love", root_path(category: "love"), class: "btn-category marker-style-love" %>
+  <%= link_to "Architecture", root_path(category: "architecture"), class: "btn-category marker-style-architecture" %>
+  <%= link_to "Horreur", root_path(category: "horreur"), class: "btn-category marker-style-horreur" %>
+  <%= link_to "Nature", root_path(category: "nature"), class: "btn-category marker-style-nature" %>
+  <%= link_to "Fantasy", root_path(category: "fantasy"), class: "btn-category marker-style-fantasy" %>
 </div>
 
-<%= render "capsules/capsules_list", capsules: capsules %>
-  </div>
+    <ul class="list-unstyled">
+      <% capsules.each do |capsule| %>
+        <li class="mt-2">
+          <%= render "shared/capsule_design", capsule: capsule %>
+      </li>
+        <% end %>
+    </ul>
+</div>


### PR DESCRIPTION
- créer une capsule : elle s'affiche bien sur la map, le son ok, le redirect aussi
- filtrer les capsules : évidemment on ne l'a plus en live comme avec le turbo, au clic, cela relance la page et affiche tout correctement (sur la map et sur le menu - Abdel j'ai laissé le tri sur la map pour le moment ^^) mais c'est sans lag, beaucoup plus propre tu avais raison
- les icones et les boutons de la navbar s'affichent bien
- sur la capsule card, pas de problème à signaler, écoute, like et comment fonctionnent, et la correction du bug de l'affichage du user est pris en compte
- la modif du profile fonctionne aussi
- ça a aussi régler le problème du redirect après le sign-up